### PR TITLE
Modify gg_facet_wrap_months function signature

### DIFF
--- a/posts/ggplot-helper-design/index.qmd
+++ b/posts/ggplot-helper-design/index.qmd
@@ -193,8 +193,8 @@ List arguments bind together user inputs that all go into the same place inside 
 
 #### Plot Helper Body
 
-```{r}
-gg_facet_wrap_months <- function(...){
+```r
+gg_facet_wrap_months <- function([arguments and defaults as shown above in 'Plot Helper Interface']){
   ## Data Helpers
   cal_data <- .events_long |>
     fill_missing_units({{ date_col }}) |>


### PR DESCRIPTION
Hi Cynthia - looks like I didn't actually get around to the pull request  on this! 🤦‍♀️ This is what I was talking about at the JSM dinner:  Thank you for again talking through your work the other day.  I think a reason I haven't quite been able to wrap my head around what you're advocating was that the gg_facte_wrap_months under `#### Plot Helper Body` is supposed to be kind of pseudo code (is that right?) and the arguments that you discuss above go where the elipsis is.  For me and I think for others, you could signal this more strongly by writing out some prose, especially as `...` has a meaning in R?  An alternative might be to just write out the complete function definition verbatim from the package (I finally consulted ggtilecal 🙌 itself to check it out) and then maybe use args(gg_facet_wrap_months) and body(gg_facet_wrap_months) to separately highlight those design components.  Curious to know what you think!

